### PR TITLE
Handle double-quoted commands

### DIFF
--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -18,7 +18,10 @@ words:
   - compilability
   - Dema
   - fileassert
+  - Hostx
+  - misparse
   - msbuild
+  - msvc
   - opencover
   - pandoc
   - reqstream
@@ -27,6 +30,7 @@ words:
   - SARIF
   - sonarmark
   - versionmark
+  - VSINSTALLDIR
   - weasyprint
   - Weasy
   - xunit

--- a/docs/user_guide/introduction.md
+++ b/docs/user_guide/introduction.md
@@ -299,6 +299,82 @@ The tool uses OS-specific overrides when running on the corresponding platform. 
 is specified for the current platform, it falls back to the default `command` and `regex`
 values.
 
+## Commands with Spaces in Paths
+
+When a tool's executable is installed at a path that contains spaces, the path must be
+enclosed in double quotes so the shell treats it as a single token.
+
+### Windows: Environment Variable Paths
+
+Many Windows tools are installed at paths exposed via environment variables. Use the variable
+directly inside double quotes:
+
+```yaml
+tools:
+  # LLVM tools installed via LLVM_PATH environment variable
+  clang-format:
+    command-win: '"%LLVM_PATH%\bin\clang-format" --version'
+    regex: 'clang-format version (?<version>.*)'
+
+  # Visual Studio's cl.exe via VSINSTALLDIR
+  msvc:
+    command-win: '"%VSINSTALLDIR%VC\Tools\MSVC\14.39.33519\bin\Hostx64\x64\cl.exe"'
+    regex: 'Version (?<version>[\d.]+)'
+```
+
+> **Note:** The entire value is single-quoted in YAML so that the inner double quotes are
+> preserved literally. VersionMark passes the command verbatim to `cmd.exe /c`, so `%VAR%`
+> expansion and quoted-path handling work exactly as they do in a normal Command Prompt.
+
+### Windows: Absolute Paths with Spaces
+
+If you know the exact path, quote just the executable portion:
+
+```yaml
+tools:
+  cmake:
+    command-win: '"C:\Program Files\CMake\bin\cmake.exe" --version'
+    command: cmake --version
+    regex: 'cmake version (?<version>\d+\.\d+\.\d+)'
+```
+
+### Windows: Quoted Path with Quoted Arguments
+
+When both the executable path **and** an argument value contain spaces, quote each part
+independently:
+
+```yaml
+tools:
+  custom-tool:
+    command-win: '"C:\Program Files\My Tool\tool.exe" --output "C:\My Output\result.txt"'
+    regex: 'version (?<version>\d+\.\d+\.\d+)'
+```
+
+### Unix/macOS: Paths with Spaces
+
+On Unix-like systems use `$VAR` syntax and the same double-quoting convention:
+
+```yaml
+tools:
+  custom-sdk:
+    command-linux: '"$CUSTOM_SDK_PATH/bin/tool" --version'
+    command-macos: '"$CUSTOM_SDK_PATH/bin/tool" --version'
+    regex: 'tool version (?<version>\d+\.\d+\.\d+)'
+```
+
+### Common Cross-Platform Pattern
+
+For a tool that needs quoting on all platforms, use the default `command` with each platform's
+variable syntax, plus OS-specific overrides where the path format differs:
+
+```yaml
+tools:
+  clang-format:
+    command: '"$LLVM_PATH/bin/clang-format" --version'
+    command-win: '"%LLVM_PATH%\bin\clang-format" --version'
+    regex: 'clang-format version (?<version>.*)'
+```
+
 ## Regular Expression Tips
 
 The regex must contain a named 'version' capture group using .NET syntax `(?<version>...)` that
@@ -591,6 +667,28 @@ tools:
 ```
 
 # Troubleshooting
+
+## Tool Path Contains Spaces (Windows)
+
+If the tool executable is at a path with spaces and you see an error like:
+
+```text
+Error: Failed to run command '"C:\Program Files\...\tool"': '"C:\Program Files\...\tool"'
+is not recognized as an internal or external command
+```
+
+The path must be double-quoted inside the command string. In YAML, single-quote the entire
+value so the inner double quotes are preserved:
+
+```yaml
+# WRONG — spaces in path cause the shell to split the executable name
+command-win: '%LLVM_PATH%\bin\clang-format --version'
+
+# CORRECT — double-quote the executable path
+command-win: '"%LLVM_PATH%\bin\clang-format" --version'
+```
+
+See [Commands with Spaces in Paths](#commands-with-spaces-in-paths) for more examples.
 
 ## Tool Not Found
 

--- a/docs/user_guide/introduction.md
+++ b/docs/user_guide/introduction.md
@@ -323,8 +323,8 @@ tools:
 ```
 
 > **Note:** The entire value is single-quoted in YAML so that the inner double quotes are
-> preserved literally. VersionMark passes the command verbatim to `cmd.exe /c`, so `%VAR%`
-> expansion and quoted-path handling work exactly as they do in a normal Command Prompt.
+> preserved literally. VersionMark executes the command via `cmd.exe` as `/c "{command}"`,
+> preserving inner quoted paths and arguments while still allowing normal `%VAR%` expansion.
 
 ### Windows: Absolute Paths with Spaces
 

--- a/src/DemaConsulting.VersionMark/Configuration/VersionMarkConfig.cs
+++ b/src/DemaConsulting.VersionMark/Configuration/VersionMarkConfig.cs
@@ -543,13 +543,17 @@ public sealed record VersionMarkConfig
     /// <exception cref="InvalidOperationException">Thrown when the command fails to execute.</exception>
     /// <remarks>
     ///     Commands are delegated to the OS shell (<c>cmd.exe /c</c> on Windows, <c>/bin/sh -c</c>
-    ///     elsewhere) via <c>ArgumentList</c> to avoid escaping issues. This supports <c>.cmd</c>/<c>.bat</c>
-    ///     files on Windows and shell features (pipes, redirects, built-ins) on all platforms.
+    ///     elsewhere) via <c>Arguments</c> (string-based) so the command is passed verbatim to the
+    ///     shell. Using <c>ArgumentList</c> would cause .NET to re-quote and escape embedded quotes,
+    ///     breaking commands like <c>"path with spaces\tool" --version</c>. This supports
+    ///     <c>.cmd</c>/<c>.bat</c> files on Windows and shell features (pipes, redirects, built-ins)
+    ///     on all platforms.
     /// </remarks>
     private static string RunCommand(string command)
     {
-        // To support .cmd/.bat files on Windows and shell features on all platforms,
-        // we run commands through the appropriate shell using ArgumentList to avoid escaping issues
+        // Pass the command verbatim to the shell via Arguments (not ArgumentList) so that embedded
+        // quotes are not re-escaped. ArgumentList applies CommandLineToArgvW-style quoting which
+        // cmd.exe does not correctly reverse, causing failures for quoted executable paths.
         var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
         try
@@ -557,13 +561,12 @@ public sealed record VersionMarkConfig
             var processStartInfo = new ProcessStartInfo
             {
                 FileName = isWindows ? "cmd.exe" : "/bin/sh",
+                Arguments = isWindows ? $"/c {command}" : $"-c {command}",
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true
             };
-            processStartInfo.ArgumentList.Add(isWindows ? "/c" : "-c");
-            processStartInfo.ArgumentList.Add(command);
 
             using var process = Process.Start(processStartInfo);
             if (process == null)

--- a/src/DemaConsulting.VersionMark/Configuration/VersionMarkConfig.cs
+++ b/src/DemaConsulting.VersionMark/Configuration/VersionMarkConfig.cs
@@ -543,17 +543,21 @@ public sealed record VersionMarkConfig
     /// <exception cref="InvalidOperationException">Thrown when the command fails to execute.</exception>
     /// <remarks>
     ///     Commands are delegated to the OS shell (<c>cmd.exe /c</c> on Windows, <c>/bin/sh -c</c>
-    ///     elsewhere) via <c>Arguments</c> (string-based) so the command is passed verbatim to the
-    ///     shell. Using <c>ArgumentList</c> would cause .NET to re-quote and escape embedded quotes,
-    ///     breaking commands like <c>"path with spaces\tool" --version</c>. This supports
-    ///     <c>.cmd</c>/<c>.bat</c> files on Windows and shell features (pipes, redirects, built-ins)
-    ///     on all platforms.
+    ///     elsewhere). On Windows, <c>Arguments</c> (string-based) is used so the command is passed
+    ///     verbatim to <c>cmd.exe</c> — <c>ArgumentList</c> would re-quote embedded quotes, breaking
+    ///     commands like <c>"%VAR%\tool" --version</c>. On Unix, <c>ArgumentList</c> is used so that
+    ///     <c>/bin/sh</c> receives <c>-c</c> and the full command string as separate argv entries, as
+    ///     required by the shell. This supports <c>.cmd</c>/<c>.bat</c> files on Windows and shell
+    ///     features (pipes, redirects, built-ins) on all platforms.
     /// </remarks>
     private static string RunCommand(string command)
     {
-        // Pass the command verbatim to the shell via Arguments (not ArgumentList) so that embedded
-        // quotes are not re-escaped. ArgumentList applies CommandLineToArgvW-style quoting which
-        // cmd.exe does not correctly reverse, causing failures for quoted executable paths.
+        // On Windows, pass the command via Arguments (string-based) so cmd.exe receives it verbatim.
+        // ArgumentList applies CommandLineToArgvW-style quoting which cmd.exe does not correctly
+        // reverse, breaking quoted executable paths such as "%VAR%\tool" --version.
+        // On Unix, use ArgumentList so that /bin/sh receives -c and the full command string as
+        // separate argv entries — if Arguments were used, .NET would split on spaces and sh would
+        // receive multiple tokens instead of a single command string.
         var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
         try
@@ -561,12 +565,27 @@ public sealed record VersionMarkConfig
             var processStartInfo = new ProcessStartInfo
             {
                 FileName = isWindows ? "cmd.exe" : "/bin/sh",
-                Arguments = isWindows ? $"/c {command}" : $"-c {command}",
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true
             };
+
+            if (isWindows)
+            {
+                // Wrap the entire command in outer quotes so cmd.exe always applies its
+                // "strip first and last quote" rule (condition 2), leaving the inner
+                // command — including any embedded quoted paths or arguments — intact.
+                // Without the outer quotes, a command such as
+                //   "%VAR%\tool" --arg "value"
+                // would cause cmd.exe to misparse the quote boundaries.
+                processStartInfo.Arguments = $"/c \"{command}\"";
+            }
+            else
+            {
+                processStartInfo.ArgumentList.Add("-c");
+                processStartInfo.ArgumentList.Add(command);
+            }
 
             using var process = Process.Start(processStartInfo);
             if (process == null)

--- a/test/DemaConsulting.VersionMark.Tests/Configuration/VersionMarkConfigTests.cs
+++ b/test/DemaConsulting.VersionMark.Tests/Configuration/VersionMarkConfigTests.cs
@@ -510,6 +510,59 @@ public partial class VersionMarkConfigTests
     }
 
     /// <summary>
+    ///     Test FindVersions on Windows with a double-quoted executable path and quoted argument.
+    /// </summary>
+    [Fact]
+    public void VersionMarkConfig_FindVersions_WindowsQuotedExecutablePathAndArgument_ReturnsVersionInfo()
+    {
+        // Arrange
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Requires Windows cmd.exe behavior");
+
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"VersionMark Quoted Path {Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        var scriptPath = Path.Combine(tempDirectory, "emit-version.cmd");
+
+        try
+        {
+            File.WriteAllText(
+                scriptPath,
+                "@echo off" + Environment.NewLine +
+                "echo tool version 1.2.3 arg=%~1");
+
+            var tools = new Dictionary<string, ToolConfig>
+            {
+                ["quoted-tool"] = new ToolConfig(
+                    new Dictionary<string, string>
+                    {
+                        [string.Empty] = $"\"{scriptPath}\" \"value with spaces\""
+                    },
+                    new Dictionary<string, string>
+                    {
+                        [string.Empty] = @"tool version (?<version>\d+\.\d+\.\d+) arg=value with spaces"
+                    }
+                )
+            };
+            var config = new VersionMarkConfig(tools);
+
+            // Act
+            var versionInfo = config.FindVersions(["quoted-tool"], "test-job");
+
+            // Assert
+            Assert.NotNull(versionInfo);
+            Assert.Single(versionInfo.Versions);
+            Assert.True(versionInfo.Versions.TryGetValue("quoted-tool", out var version));
+            Assert.Equal("1.2.3", version);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+        }
+    }
+
+    /// <summary>
     ///     Test FindVersions with multiple tools.
     /// </summary>
     [Fact]


### PR DESCRIPTION
# Pull Request

## Description

This fixes handling of commands that are double-quoted to handle spaces in path names.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #

## Pre-Submission Checklist

Before submitting this pull request, ensure you have completed the following:

### Build and Test

- [x] Code builds successfully and all tests pass: `pwsh ./build.ps1`
- [x] Code produces zero warnings

### Code Quality

- [x] New code has appropriate XML documentation comments
- [ ] Static analyzer warnings have been addressed

### Quality Checks

Please run the following checks before submitting:

- [x] **All linters pass**: `pwsh ./lint.ps1`

### Testing

- [ ] Added unit tests for new functionality
- [ ] Updated existing tests if behavior changed
- [ ] All tests follow the AAA (Arrange, Act, Assert) pattern
- [ ] Test coverage is maintained or improved

### Documentation

- [ ] Updated README.md (if applicable)
- [ ] Updated docs/ documentation (if applicable)
- [ ] Added code examples for new features (if applicable)
- [ ] Updated requirements.yaml (if applicable)

## Additional Notes

<!-- Add any additional context, screenshots, or information that reviewers should know -->
